### PR TITLE
use dnspython instead of deprecated dnspython3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 boto3>=1.2.3
 PyYAML
-dnspython ; python_version <= '2.7'
-dnspython3 ; python_version > '3.3'
+dnspython>=1.15.0


### PR DESCRIPTION
dnspython3 has been superseded by the regular dnspython kit, which now supports both Python 2 and Python 3.
