### PR TITLE
Exit with non-zero code on single run error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.4"
   - "2.7"
 install:
-  - pip install -r requirements.txt
+  - pip install --upgrade setuptools -r requirements.txt
   - pip install coveralls
 script:
   - python setup.py test

--- a/berry/__main__.py
+++ b/berry/__main__.py
@@ -1,4 +1,4 @@
 import berry.cli
 
 if __name__ == '__main__':
-    berry.cli.main()
+    exit(berry.cli.main())


### PR DESCRIPTION
Hopefully fixes #5: if flag --once is specified, and an error occurs then exit with code 1.
This change should help with using berry in shell scripts (e.g. in integration builds).

In continuous mode the solution is less clear so I decided to handle most useful case for this, single update mode.

The PR includes build-fix for master also.